### PR TITLE
logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,12 @@ network = { path = "network", package="imp-network"}
 p2p = { path = "network/p2p", package="imp-p2p"}
 agent = { path = "agent", package="imp-agent"}
 datatypes = { path = "datatypes", package="imp-datatypes"}
+utils = { path = "utils", package="imp-utils"}
 
 tokio-02 = { version = "0.2", features = ["full"], package = "tokio" }
 tokio-01 = { version = "0.1.22", package = "tokio"}
 tokio-compat = { version = "0.1.5", features = ["rt-full"] }
-slog-term = "^2.4.0"
-slog-async = "^2.3.0"
 slog = { version = "2.5.2" , features = ["max_level_trace"] }
-env_logger = "0.6.0"
 target_info = "0.1.0"
 clap = "2.33.0"
 error-chain = "0.12.1"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -11,3 +11,4 @@ network = { path = "../network", package="imp-network"}
 datatypes = { path = "../datatypes", package="imp-datatypes"}
 tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
+slog = { version = "2.5.2" , features = ["max_level_trace"] }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -11,3 +11,4 @@ datatypes = { path = "../datatypes", package="imp-datatypes"}
 tokio = { version = "0.2", features = ["full"] }
 clap = "2.33.0"
 futures = "0.3"
+slog = { version = "2.5.2" , features = ["max_level_trace"] }

--- a/network/p2p/Cargo.toml
+++ b/network/p2p/Cargo.toml
@@ -10,6 +10,7 @@ local = ["mothra-local", "eth2-libp2p-local"]
 
 [dependencies]
 datatypes = { path = "../../datatypes", package="imp-datatypes"}
+utils = { path = "../../utils", package="imp-utils"}
 mothra = { git = "https://github.com/prrkl/mothra", branch = "master", package = "mothra", optional = true }
 mothra-local = { path = "../../../mothra/core", package = "mothra", optional = true }
 eth2-libp2p = { version = "0.2.0", package = "eth2-libp2p", optional = true }

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -1,21 +1,28 @@
 use datatypes::Message;
+use slog::{debug, info, o, trace, warn};
 use std::any::type_name;
 use std::sync::Arc;
 use tokio::sync::watch;
 use tokio::{runtime, signal, task, time};
 
-pub struct Service {}
+pub struct Service {
+    log: slog::Logger,
+}
 
 impl Service {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Service {})
+    pub fn new(log: slog::Logger) -> Self {
+        Service { log }
     }
-    pub async fn spawn(&self, mut shutdown_rx: watch::Receiver<Message>) {
+    pub async fn spawn(self, mut shutdown_rx: watch::Receiver<Message>) {
         task::spawn(async move {
             loop {
                 match shutdown_rx.recv().await {
                     Some(Message::Shutdown) => {
-                        println!("{:?}: shutdown message received.", type_name::<Service>());
+                        info!(
+                            self.log,
+                            "{:?}: shutdown message received.",
+                            type_name::<Service>()
+                        );
                         break;
                     }
                     _ => (),

--- a/sim/mock-node/Cargo.toml
+++ b/sim/mock-node/Cargo.toml
@@ -10,6 +10,7 @@ default = ["mothra", "eth2-libp2p"]
 local = ["mothra-local", "eth2-libp2p-local"]
 
 [dependencies]
+utils = { path = "../../utils", package="imp-utils"}
 p2p = { path = "../../network/p2p", package="imp-p2p"}
 mothra = { git = "https://github.com/prrkl/mothra", branch = "master", package = "mothra", optional = true }
 mothra-local = { path = "../../../mothra/core", package = "mothra", optional = true }
@@ -18,10 +19,7 @@ eth2-libp2p-local = { path = "../../../lighthouse/beacon_node/eth2-libp2p", pack
 
 tokio = "0.1.22"
 tokio-compat = { version = "0.1.5", features = ["rt-full"] }
-slog-term = "^2.4.0"
-slog-async = "^2.3.0"
 slog = { version = "2.5.2" , features = ["max_level_trace"] }
-env_logger = "0.6.0"
 target_info = "0.1.0"
 clap = "2.33.0"
 

--- a/sim/mock-node/src/main.rs
+++ b/sim/mock-node/src/main.rs
@@ -1,7 +1,6 @@
 extern crate target_info;
 use clap::App;
-use env_logger::Env;
-use slog::{debug, info, o, trace, warn, Drain, Level, Logger};
+use slog::{debug, info, o, trace, warn};
 use std::{thread, time};
 use tokio_compat::runtime::Runtime;
 
@@ -21,42 +20,35 @@ const PROTOCOL_VERSION: &str = "imp/libp2p";
 fn main() {
     let start = time::Instant::now();
     // Parse the CLI parameters.
-    let matches = App::new(CLIENT_NAME)
+    let arg_matches = App::new(CLIENT_NAME)
         .version(clap::crate_version!())
         .author("Jonny Rhea")
         .about("Eth2 mock node")
         .subcommand(cli_app())
         .get_matches();
 
-    let runtime = Runtime::new()
-        .map_err(|e| format!("Failed to start runtime: {:?}", e))
-        .unwrap();
-    let executor = runtime.executor();
+    // get mothra subcommand args matches
+    let mothra_arg_matches = &arg_matches.subcommand_matches("mothra").unwrap();
+
+    let debug_level = mothra_arg_matches.value_of("debug-level").unwrap();
+
+    // configure logging
+    let slog = utils::config_logger(debug_level, true);
+    let log = slog.new(o!("mock-node" => "mock-node"));
 
     let mut config = Mothra::get_config(
         Some(CLIENT_NAME.into()),
         Some(format!("v{}", env!("CARGO_PKG_VERSION"))),
         Some(PROTOCOL_VERSION.into()),
-        &matches.subcommand_matches("mothra").unwrap(),
+        &mothra_arg_matches,
     );
-    // configure logging
-    env_logger::Builder::from_env(Env::default()).init();
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build();
-    let drain = match config.debug_level.as_str() {
-        "info" => drain.filter_level(Level::Info),
-        "debug" => drain.filter_level(Level::Debug),
-        "trace" => drain.filter_level(Level::Trace),
-        "warn" => drain.filter_level(Level::Warning),
-        "error" => drain.filter_level(Level::Error),
-        "crit" => drain.filter_level(Level::Critical),
-        _ => drain.filter_level(Level::Info),
-    };
-    let slog = Logger::root(drain.fuse(), o!());
-    let log = slog.new(o!("mock-node" => "mock-node"));
 
     config.network_config.topics = topics::create_topics(FORK_DIGEST);
+
+    let runtime = Runtime::new()
+        .map_err(|e| format!("Failed to start runtime: {:?}", e))
+        .unwrap();
+    let executor = runtime.executor();
 
     let (network_globals, network_send, network_exit) = Mothra::new(
         config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
-extern crate target_info;
-#[macro_use]
 extern crate error_chain;
+extern crate target_info;
 use clap::{App, Arg};
-use env_logger::Env;
-use slog::{debug, info, o, trace, warn, Drain, Level, Logger};
+use slog::{debug, info, o, trace, warn};
 use std::time::Duration;
 use tokio_01::prelude::future::Future;
 use tokio_02::sync::watch;
@@ -15,7 +13,7 @@ use network::NetworkService;
 use p2p::{cli_app, P2PService};
 
 const CLIENT_NAME: &str = "imp";
-const PROTOCOL_VERSION: &str = "imp/libp2p";
+const P2P_PROTOCOL_VERSION: &str = "imp/libp2p";
 
 fn main() -> Result<(), std::io::Error> {
     // Parse the CLI parameters.
@@ -23,6 +21,14 @@ fn main() -> Result<(), std::io::Error> {
         .version(clap::crate_version!())
         .author("Jonny Rhea")
         .about("Eth2 Network Agent")
+        .arg(
+            Arg::with_name("p2p-protocol-version")
+                .long("p2p-protocol-version")
+                .value_name("P2P_PROTOCOL_VERSION")
+                .help("P2P protocol version to advertise.")
+                .takes_value(true)
+                .default_value(P2P_PROTOCOL_VERSION),
+        )
         .arg(
             Arg::with_name("debug-level")
                 .long("debug-level")
@@ -35,46 +41,39 @@ fn main() -> Result<(), std::io::Error> {
         .subcommand(cli_app())
         .get_matches();
 
-    let debug_level = arg_matches
-        .value_of("debug-level")
-        .ok_or_else(|| "Expected --debug-level flag".to_string())
-        .unwrap();
+    let p2p_protocol_version = arg_matches.value_of("p2p-protocol-version").unwrap();
+
+    // default to this debug-level value.
+    // if mothra submommand has a specific debug-level,
+    // then mothra will use it
+    let debug_level = arg_matches.value_of("debug-level").unwrap();
 
     // configure logging
-    env_logger::Builder::from_env(Env::default()).init();
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build();
-    let drain = match debug_level {
-        "info" => drain.filter_level(Level::Info),
-        "debug" => drain.filter_level(Level::Debug),
-        "trace" => drain.filter_level(Level::Trace),
-        "warn" => drain.filter_level(Level::Warning),
-        "error" => drain.filter_level(Level::Error),
-        "crit" => drain.filter_level(Level::Critical),
-        _ => drain.filter_level(Level::Info),
-    };
-    let slog = Logger::root(drain.fuse(), o!());
+    let slog = utils::config_logger(debug_level, true);
     let log = slog.new(o!("imp" => "imp"));
 
     let client_name: String = CLIENT_NAME.into();
     let platform: String = format!("v{}", env!("CARGO_PKG_VERSION"));
-    let protocol_version: String = PROTOCOL_VERSION.into();
 
     let mut runtime = tokio_compat::runtime::Runtime::new()?;
+
+    info!(log, "Starting imp");
+
     let p2p_service = P2PService::new(
         &runtime.executor(),
         client_name,
         platform,
-        protocol_version,
+        p2p_protocol_version.into(),
         &arg_matches,
         log.new(o!("imp" => "P2PService")),
     );
-    let network_service = NetworkService::new();
-    let agent = Agent::new(network_service.clone());
+    let network_service = NetworkService::new(log.new(o!("imp" => "NetworkService")));
+    let agent = Agent::new(log.new(o!("imp" => "Agent")));
 
+    let (shutdown_tx, shutdown_rx) = watch::channel::<Message>(Message::None);
+
+    // main "event loop"
     runtime.block_on_std(async move {
-        let (shutdown_tx, shutdown_rx) = watch::channel::<Message>(Message::None);
         async move {
             let rx = shutdown_rx.clone();
             task::spawn(async move {
@@ -84,16 +83,15 @@ fn main() -> Result<(), std::io::Error> {
             agent.spawn(shutdown_rx).await;
         }
         .await;
-        // block the current thread until Ctrl+C is received.
+        // block the current thread until SIGINTis received.
         signal::ctrl_c().await.expect("failed to listen for event");
-        println!("Sending shutdown signal.");
-        let _ = shutdown_tx.broadcast(Message::Shutdown);
     });
+
+    info!(log, "Sending shutdown signal.");
+    let _ = shutdown_tx.broadcast(Message::Shutdown);
 
     // Shutdown the runtime
     runtime.shutdown_on_idle().wait().unwrap();
-
-    println!("Exiting imp.");
-
+    info!(log.clone(), "Exiting imp.");
     Ok(())
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "imp-utils"
+version = "0.1.0"
+authors = ["jonny rhea <jonny.rhea@consensys.com>"]
+edition = "2018"
+
+[dependencies]
+slog-term = "^2.4.0"
+slog-async = "^2.3.0"
+slog = { version = "2.5.2" , features = ["max_level_trace"] }
+env_logger = "0.6.0"
+clap = "2.33.0"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,0 +1,22 @@
+use env_logger::Env;
+use slog::{debug, info, o, trace, warn, Drain, Level, Logger};
+use clap::{App, Arg};
+
+pub fn config_logger(debug_level: &str, init: bool) -> slog::Logger {
+    if init {
+        env_logger::Builder::from_env(Env::default()).init();
+    }
+    let decorator = slog_term::TermDecorator::new().build();
+    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).build();
+    let drain = match debug_level {
+        "info" => drain.filter_level(Level::Info),
+        "debug" => drain.filter_level(Level::Debug),
+        "trace" => drain.filter_level(Level::Trace),
+        "warn" => drain.filter_level(Level::Warning),
+        "error" => drain.filter_level(Level::Error),
+        "crit" => drain.filter_level(Level::Critical),
+        _ => drain.filter_level(Level::Info),
+    };
+    Logger::root(drain.fuse(), o!())
+}


### PR DESCRIPTION
- created `util::config_logger` for applying debug-log options
- debug-log can be configured for imp and mothra independently (wasn't fully functional before this)
- log enabled in agent, network, and p2p
